### PR TITLE
FIX: generateExp must be used in method public 'generate'

### DIFF
--- a/src/jwt.js
+++ b/src/jwt.js
@@ -22,6 +22,7 @@
          */
         generate: function(claims, secret, alg) {
             claims = claims || {};
+            claims.exp = claims.exp || jwt._generateExp();
 
             if (!claims.iss) {
                 throw new Error('jwt:undefined:iss');
@@ -38,8 +39,6 @@
 
         _generate: function(claims, secret, alg){
             alg = alg || jwt.ALGORITHM;
-
-            claims.exp = claims.exp || jwt._generateExp();
             
             // Ensure claims specific order
             var claimsKeys = [


### PR DESCRIPTION
generate expiration time by defect must be used in method public 'generate'. Method _generate must allow claims without expiration time.