### PR TITLE
Fix bug: Encoding query params with few equal symbols

### DIFF
--- a/dist/corbel.js
+++ b/dist/corbel.js
@@ -1586,14 +1586,17 @@
             var urlComponents = url.split('?');
             if (urlComponents.length > 1) {
                 return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {
-                    return operator.split('=');
-                }).map(function(splitted) {
+                    var equalSymbolPosition = operator.indexOf('=');
+                    var splitted = [];
+                    splitted.push(operator.substring(0, equalSymbolPosition));
+                    splitted.push(operator.substring(equalSymbolPosition + 1, operator.length));
                     return [splitted[0], encodeURIComponent(splitted[1])].join('=');
                 }).join('&');
             }
 
             return url;
         };
+
 
         request._nodeAjax = function(params, resolver) {
             var requestAjax = require('request');

--- a/dist/corbel.js
+++ b/dist/corbel.js
@@ -348,8 +348,12 @@
                 throw new Error('expected params to be an Object type, but got ' + typeof params);
             }
 
+            function getJsonEncodedStringify(param) {
+                return encodeURIComponent(JSON.stringify(param));
+            }
+
             if (params.aggregation) {
-                result = 'api:aggregation=' + JSON.stringify(params.aggregation);
+                result = 'api:aggregation=' + getJsonEncodedStringify(params.aggregation);
             }
 
             function queryObjectToString(params, key) {
@@ -365,9 +369,7 @@
                         query = JSON.parse(JSON.stringify(params[key]));
                     }
 
-                    query = JSON.stringify(query);
-
-                    result += query;
+                    result += getJsonEncodedStringify(query);
 
                     return result;
                 } catch (e) {
@@ -404,21 +406,21 @@
 
             if (params.search) {
                 result += result ? '&' : '';
-                result += 'api:search=' + JSON.stringify(params.search);
+                result += 'api:search=' + getJsonEncodedStringify(params.search);
 
                 if (params.hasOwnProperty('binded')) {
-                    result += '&api:binded=' + JSON.stringify(params.binded);
+                    result += '&api:binded=' + getJsonEncodedStringify(params.binded);
                 }
             }
 
             if (params.distinct) {
                 result += result ? '&' : '';
-                result += 'api:distinct=' + (params.distinct instanceof Array ? params.distinct.join(',') : params.distinct);
+                result += 'api:distinct=' + encodeURIComponent((params.distinct instanceof Array ? params.distinct.join(',') : params.distinct));
             }
 
             if (params.sort) {
                 result += result ? '&' : '';
-                result += 'api:sort=' + JSON.stringify(params.sort);
+                result += 'api:sort=' + getJsonEncodedStringify(params.sort);
             }
 
             if (params.pagination) {
@@ -436,7 +438,7 @@
             if (params.customQueryParams) {
                 Object.keys(params.customQueryParams).forEach(function(param) {
                     result += result ? '&' : '';
-                    result += param + '=' + params.customQueryParams[param];
+                    result += param + '=' + encodeURIComponent(params.customQueryParams[param]);
                 });
             }
 
@@ -1454,8 +1456,6 @@
 
             params = rewriteRequestToPostIfUrlLengthIsTooLarge(options, params);
 
-            params.url = encodeQueryString(params.url);
-
             // default content-type
             params.headers['content-type'] = options.contentType || 'application/json';
 
@@ -1578,25 +1578,6 @@
             });
             return form;
         };
-
-        var encodeQueryString = function(url) {
-            if (!url) {
-                return url;
-            }
-            var urlComponents = url.split('?');
-            if (urlComponents.length > 1) {
-                return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {
-                    var equalSymbolPosition = operator.indexOf('=');
-                    var splitted = [];
-                    splitted.push(operator.substring(0, equalSymbolPosition));
-                    splitted.push(operator.substring(equalSymbolPosition + 1, operator.length));
-                    return [splitted[0], encodeURIComponent(splitted[1])].join('=');
-                }).join('&');
-            }
-
-            return url;
-        };
-
 
         request._nodeAjax = function(params, resolver) {
             var requestAjax = require('request');

--- a/dist/corbel.with-polyfills.js
+++ b/dist/corbel.with-polyfills.js
@@ -1344,8 +1344,12 @@
                 throw new Error('expected params to be an Object type, but got ' + typeof params);
             }
 
+            function getJsonEncodedStringify(param) {
+                return encodeURIComponent(JSON.stringify(param));
+            }
+
             if (params.aggregation) {
-                result = 'api:aggregation=' + JSON.stringify(params.aggregation);
+                result = 'api:aggregation=' + getJsonEncodedStringify(params.aggregation);
             }
 
             function queryObjectToString(params, key) {
@@ -1361,9 +1365,7 @@
                         query = JSON.parse(JSON.stringify(params[key]));
                     }
 
-                    query = JSON.stringify(query);
-
-                    result += query;
+                    result += getJsonEncodedStringify(query);
 
                     return result;
                 } catch (e) {
@@ -1400,21 +1402,21 @@
 
             if (params.search) {
                 result += result ? '&' : '';
-                result += 'api:search=' + JSON.stringify(params.search);
+                result += 'api:search=' + getJsonEncodedStringify(params.search);
 
                 if (params.hasOwnProperty('binded')) {
-                    result += '&api:binded=' + JSON.stringify(params.binded);
+                    result += '&api:binded=' + getJsonEncodedStringify(params.binded);
                 }
             }
 
             if (params.distinct) {
                 result += result ? '&' : '';
-                result += 'api:distinct=' + (params.distinct instanceof Array ? params.distinct.join(',') : params.distinct);
+                result += 'api:distinct=' + encodeURIComponent((params.distinct instanceof Array ? params.distinct.join(',') : params.distinct));
             }
 
             if (params.sort) {
                 result += result ? '&' : '';
-                result += 'api:sort=' + JSON.stringify(params.sort);
+                result += 'api:sort=' + getJsonEncodedStringify(params.sort);
             }
 
             if (params.pagination) {
@@ -1432,7 +1434,7 @@
             if (params.customQueryParams) {
                 Object.keys(params.customQueryParams).forEach(function(param) {
                     result += result ? '&' : '';
-                    result += param + '=' + params.customQueryParams[param];
+                    result += param + '=' + encodeURIComponent(params.customQueryParams[param]);
                 });
             }
 
@@ -2450,8 +2452,6 @@
 
             params = rewriteRequestToPostIfUrlLengthIsTooLarge(options, params);
 
-            params.url = encodeQueryString(params.url);
-
             // default content-type
             params.headers['content-type'] = options.contentType || 'application/json';
 
@@ -2574,25 +2574,6 @@
             });
             return form;
         };
-
-        var encodeQueryString = function(url) {
-            if (!url) {
-                return url;
-            }
-            var urlComponents = url.split('?');
-            if (urlComponents.length > 1) {
-                return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {
-                    var equalSymbolPosition = operator.indexOf('=');
-                    var splitted = [];
-                    splitted.push(operator.substring(0, equalSymbolPosition));
-                    splitted.push(operator.substring(equalSymbolPosition + 1, operator.length));
-                    return [splitted[0], encodeURIComponent(splitted[1])].join('=');
-                }).join('&');
-            }
-
-            return url;
-        };
-
 
         request._nodeAjax = function(params, resolver) {
             var requestAjax = require('request');

--- a/dist/corbel.with-polyfills.js
+++ b/dist/corbel.with-polyfills.js
@@ -2582,14 +2582,17 @@
             var urlComponents = url.split('?');
             if (urlComponents.length > 1) {
                 return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {
-                    return operator.split('=');
-                }).map(function(splitted) {
+                    var equalSymbolPosition = operator.indexOf('=');
+                    var splitted = [];
+                    splitted.push(operator.substring(0, equalSymbolPosition));
+                    splitted.push(operator.substring(equalSymbolPosition + 1, operator.length));
                     return [splitted[0], encodeURIComponent(splitted[1])].join('=');
                 }).join('&');
             }
 
             return url;
         };
+
 
         request._nodeAjax = function(params, resolver) {
             var requestAjax = require('request');

--- a/src/request.js
+++ b/src/request.js
@@ -248,8 +248,6 @@
 
     params = rewriteRequestToPostIfUrlLengthIsTooLarge(options, params);
 
-    params.url = encodeQueryString(params.url);
-
     // default content-type
     params.headers['content-type'] = options.contentType || 'application/json';
 
@@ -372,25 +370,6 @@
     });
     return form;
   };
-
-  var encodeQueryString = function(url) {
-    if (!url) {
-      return url;
-    }
-    var urlComponents = url.split('?');
-    if (urlComponents.length > 1) {
-      return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {          
-        var equalSymbolPosition = operator.indexOf('=');
-        var splitted = [];
-        splitted.push(operator.substring(0,equalSymbolPosition));
-        splitted.push(operator.substring(equalSymbolPosition + 1, operator.length));
-        return [splitted[0], encodeURIComponent(splitted[1])].join('=');
-      }).join('&');
-    }
-
-    return url;
-  };
-
   
   request._nodeAjax = function(params, resolver) {
     var requestAjax = require('request');

--- a/src/request.js
+++ b/src/request.js
@@ -379,9 +379,11 @@
     }
     var urlComponents = url.split('?');
     if (urlComponents.length > 1) {
-      return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {
-        return operator.split('=');
-      }).map(function(splitted) {
+      return urlComponents[0] + '?' + urlComponents[1].split('&').map(function(operator) {          
+        var equalSymbolPosition = operator.indexOf('=');
+        var splitted = [];
+        splitted.push(operator.substring(0,equalSymbolPosition));
+        splitted.push(operator.substring(equalSymbolPosition + 1, operator.length));
         return [splitted[0], encodeURIComponent(splitted[1])].join('=');
       }).join('&');
     }
@@ -389,6 +391,7 @@
     return url;
   };
 
+  
   request._nodeAjax = function(params, resolver) {
     var requestAjax = require('request');
     if (request.isCrossDomain(params.url) && params.withCredentials && params.useCookies) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -197,8 +197,12 @@
       throw new Error('expected params to be an Object type, but got ' + typeof params);
     }
 
+    function getJsonEncodedStringify(param) {
+      return encodeURIComponent(JSON.stringify(param));    
+    }
+
     if (params.aggregation) {
-      result = 'api:aggregation=' + JSON.stringify(params.aggregation);
+      result = 'api:aggregation=' + getJsonEncodedStringify(params.aggregation);
     }
 
     function queryObjectToString(params, key) {
@@ -212,11 +216,9 @@
         } else {
           //Clone the object we don't want to modify the original query object
           query = JSON.parse(JSON.stringify(params[key]));
-        }
+        }   
 
-        query = JSON.stringify(query);
-
-        result += query;
+        result += getJsonEncodedStringify(query);
 
         return result;
       } catch (e) {
@@ -253,21 +255,21 @@
 
     if (params.search) {
       result += result ? '&' : '';
-      result += 'api:search=' + JSON.stringify(params.search);
+      result += 'api:search=' + getJsonEncodedStringify(params.search);
 
       if (params.hasOwnProperty('binded')) {
-        result += '&api:binded=' + JSON.stringify(params.binded);
+        result += '&api:binded=' + getJsonEncodedStringify(params.binded);
       }
     }
 
     if (params.distinct) {
       result += result ? '&' : '';
-      result += 'api:distinct=' + (params.distinct instanceof Array ? params.distinct.join(',') : params.distinct);
+      result += 'api:distinct=' + encodeURIComponent((params.distinct instanceof Array ? params.distinct.join(',') : params.distinct));
     }
 
     if (params.sort) {
       result += result ? '&' : '';
-      result += 'api:sort=' + JSON.stringify(params.sort);
+      result += 'api:sort=' + getJsonEncodedStringify(params.sort);
     }
 
     if (params.pagination) {
@@ -285,7 +287,7 @@
     if (params.customQueryParams) {
       Object.keys(params.customQueryParams).forEach(function(param) {
         result += result ? '&' : '';
-        result += param + '=' + params.customQueryParams[param];
+        result += param + '=' + encodeURIComponent(params.customQueryParams[param]);
       });
     }
 

--- a/test/browser/unit/request.js
+++ b/test/browser/unit/request.js
@@ -255,25 +255,6 @@ describe('corbel-js browser', function() {
       });
     });
 
-    it('send mehtod encodes url parameters', function(done) {
-      var _browserAjaxStub = sinon.stub(request, '_browserAjax', function(params, resolver) {
-        resolver.resolve();
-      });
-      var queryArgs = 'param1=1&param2=2&param3=3&combine=3+4';
-      var parsedQueryArgs = encodeURI(queryArgs);
-      parsedQueryArgs = parsedQueryArgs.replace('+', encodeURIComponent('+'));
-      url += '?';
-
-      expect(request.send({
-        method: 'GET',
-        url: url + queryArgs
-      })).to.be.fulfilled.then(function() {
-        expect(_browserAjaxStub.callCount).to.be.equal(1);
-        expect(_browserAjaxStub.getCall(0).args[0].url).to.be.equal(url + parsedQueryArgs);
-      }).should.notify(done);
-
-    });
-
     it.skip('send too large GET rewrite to POST and active override method header', function(done) {
       var responseData = {
         DATA: 'DATA'

--- a/test/node/unit/assets.js
+++ b/test/node/unit/assets.js
@@ -75,7 +75,7 @@ describe('In Assets module we can', function() {
         corbelDriver.assets.asset().get(params);
 
         var callRequestParam = corbelRequestStub.getCall(0).args[0];
-        expect(callRequestParam.url).to.be.equal(ASSET_URL + '?api:query=[{"$eq":{"field":"value"}}]&api:sort={"field":"asc"}&api:page=3&api:pageSize=2');
+        expect(callRequestParam.url).to.be.equal(ASSET_URL + '?api:query=' + encodeURIComponent('[{"$eq":{"field":"value"}}]') + '&api:sort=' + encodeURIComponent('{"field":"asc"}') + '&api:page=3&api:pageSize=2');
         expect(callRequestParam.query).to.be.equal();
         expect(callRequestParam.method).to.be.equal('GET');
     });
@@ -110,7 +110,7 @@ describe('In Assets module we can', function() {
         corbelDriver.assets.asset('all').get(params);
 
         var callRequestParam = corbelRequestStub.getCall(0).args[0];
-        expect(callRequestParam.url).to.be.equal(ASSET_URL + '/all?' + 'api:query=[{"$eq":{"field":"value"}}]&api:sort={"field":"asc"}&api:page=3&api:pageSize=2');
+        expect(callRequestParam.url).to.be.equal(ASSET_URL + '/all?' + 'api:query=' + encodeURIComponent('[{"$eq":{"field":"value"}}]') + '&api:sort=' + encodeURIComponent('{"field":"asc"}') + '&api:page=3&api:pageSize=2');
         expect(callRequestParam.method).to.be.equal('GET');
     });
 
@@ -123,7 +123,7 @@ describe('In Assets module we can', function() {
         corbelDriver.assets.asset('all').get(params);
 
         var callRequestParam = corbelRequestStub.getCall(0).args[0];
-        expect(callRequestParam.url).to.be.equal(ASSET_URL + '/all?' + 'api:aggregation={\"$count\":\"*\"}');
+        expect(callRequestParam.url).to.be.equal(ASSET_URL + '/all?' + 'api:aggregation=' + encodeURIComponent('{\"$count\":\"*\"}'));
         expect(callRequestParam.method).to.be.equal('GET');
     });
 

--- a/test/node/unit/baseUrlIntegrity.js
+++ b/test/node/unit/baseUrlIntegrity.js
@@ -8,7 +8,7 @@ var corbel = require('../../../dist/corbel.js'),
 
 var TEST_ENDPOINT = 'https://resources-mycorbel.com/v1.0/domain-example/',
 
-  URL_EXAMPLE_RESOURCES = TEST_ENDPOINT + 'resource/resource:entity?api:search={"text":"test"}';
+  URL_EXAMPLE_RESOURCES = TEST_ENDPOINT + 'resource/resource:entity?api:search=' + encodeURIComponent('{"text":"test"}');
 
 var CONFIG = {
   clientId: 'clientId',

--- a/test/node/unit/ec.js
+++ b/test/node/unit/ec.js
@@ -79,7 +79,7 @@ describe('In EC module', function() {
       expect(callRequestParam.url).to.be.include(EC_URL + 'product');
       expect(callRequestParam.method).to.be.equal('GET');
       console.log(callRequestParam);
-      expect(callRequestParam.url).to.contain('api:query=[{"$eq":{"field":"value"}}]&api:sort={"field":"asc"}&api:page=3&api:pageSize=2');
+      expect(callRequestParam.url).to.contain('api:query=' + encodeURIComponent('[{"$eq":{"field":"value"}}]') + '&api:sort=' + encodeURIComponent('{"field":"asc"}') + '&api:page=3&api:pageSize=2');
     });
 
     it('update one without an id', function() {

--- a/test/node/unit/notifications.js
+++ b/test/node/unit/notifications.js
@@ -79,7 +79,7 @@ describe('In Notifications module we can', function() {
         var paramsRecived = corbelRequestStub.getCall(0).args[0];
         var url = paramsRecived.url.split('?');
         expect(url).to.be.include(NOTIFICATION_URL);
-        expect(url).to.be.include('api:query=[{"$eq":{"type":"mail"}}]&api:sort={"field":"asc"}');
+        expect(url).to.be.include('api:query=' + encodeURIComponent('[{"$eq":{"type":"mail"}}]') + '&api:sort=' + encodeURIComponent('{"field":"asc"}'));
         expect(paramsRecived.method).to.be.equal('GET');
     });
 

--- a/test/node/unit/request.js
+++ b/test/node/unit/request.js
@@ -134,30 +134,6 @@ describe('corbel-js node', function() {
       });
     });
 
-    it('send mehtod encodes url parameters', function(done) {
-      var _nodeAjaxStub = sandbox.stub(request, '_nodeAjax', function(params, resolver) {
-        resolver.resolve();
-      });
-
-      var queryArgs = 'param1=1&param2=2&param3=3&combine=3+4';
-      var parsedQueryArgs = encodeURI(queryArgs);
-      parsedQueryArgs = parsedQueryArgs.replace('+', encodeURIComponent('+'));
-      url += '?'; 
-
-      var promise = request.send({
-        method: 'GET',
-        url: url + queryArgs
-      });
-
-      expect(promise)
-        .to.be.fulfilled
-        .then(function() {
-          expect(_nodeAjaxStub.callCount).to.be.equal(1);
-          expect(_nodeAjaxStub.getCall(0).args[0].url).to.be.equal(url + parsedQueryArgs);
-        })
-        .should.notify(done);
-    });
-
     it('send method sends an stream, parse not necessary', function(done) {
         var _nodeAjaxStub = sandbox.stub(request, '_nodeAjax', function(params, resolver) {
           resolver.resolve();

--- a/test/node/unit/resources.js
+++ b/test/node/unit/resources.js
@@ -8,13 +8,13 @@ var corbel = require('../../../dist/corbel.js'),
 
 var TEST_ENDPOINT = 'https://resources-qa.bqws.io/v1.0/domain-example/',
 
-  DEFAULT_QUERY_OBJECT_STRING = '[{"$eq":{"field3":true}},{"$eq":{"field4":true}},{"$gt":{"field5":"value"}},{"$gte":{"field5":"value"}},{"$lt":{"field5":"value"}},{"$lte":{"field5":"value"}},{"$ne":{"field5":"value"}},{"$in":{"field2":["pepe","juan"]}},{"$all":{"field5":["pepe","juan"]}},{"$like":{"field5":"value"}}]',
+  DEFAULT_QUERY_OBJECT_STRING = encodeURIComponent('[{"$eq":{"field3":true}},{"$eq":{"field4":true}},{"$gt":{"field5":"value"}},{"$gte":{"field5":"value"}},{"$lt":{"field5":"value"}},{"$lte":{"field5":"value"}},{"$ne":{"field5":"value"}},{"$in":{"field2":["pepe","juan"]}},{"$all":{"field5":["pepe","juan"]}},{"$like":{"field5":"value"}}]'),
 
-  DEFAULT_SIMPLE_CONDITION_OBJECT_STRING = '[{\"$eq\":{\"test\":2}}]',
+  DEFAULT_SIMPLE_CONDITION_OBJECT_STRING = encodeURIComponent('[{\"$eq\":{\"test\":2}}]'),
 
-  DEFAULT_MULTIPLE_CONDITION_OBJECT_STRING = '[{\"$eq\":{\"test\":2}}]&api:condition=[{\"$eq\":{\"test\":3}}]',
+  DEFAULT_MULTIPLE_CONDITION_OBJECT_STRING = encodeURIComponent('[{\"$eq\":{\"test\":2}}]') + '&api:condition=' + encodeURIComponent('[{\"$eq\":{\"test\":3}}]'),
 
-  URL_COLLECTION_DECODED = TEST_ENDPOINT + 'resource/resource:entity?api:query=' + DEFAULT_QUERY_OBJECT_STRING + '&api:search={"text":"test"}&api:distinct=text,field1&api:sort={"field1":"asc"}&api:page=1&api:pageSize=5',
+  URL_COLLECTION_DECODED = TEST_ENDPOINT + 'resource/resource:entity?api:query=' + DEFAULT_QUERY_OBJECT_STRING + '&api:search=' + encodeURIComponent('{"text":"test"}') + '&api:distinct=' + encodeURIComponent('text,field1') + '&api:sort=' + encodeURIComponent('{"field1":"asc"}') + '&api:page=1&api:pageSize=5',
 
   URL_SIMPLE_CONDITION_DECODED = TEST_ENDPOINT + 'resource/resource:entity?api:condition=' + DEFAULT_SIMPLE_CONDITION_OBJECT_STRING,
 
@@ -222,7 +222,7 @@ describe('corbel resources module', function() {
 
   it('generate resource query correctly', function() {
     var urlDecoded = TEST_ENDPOINT + 'resource/resource:entity?api:query=' + DEFAULT_QUERY_OBJECT_STRING +
-      '&api:search={"text":"test"}&api:distinct=text,field1&api:sort={"field1":"asc"}&api:page=0&api:pageSize=0';
+      '&api:search=' + encodeURIComponent('{"text":"test"}') + '&api:distinct=' + encodeURIComponent('text,field1') + '&api:sort=' + encodeURIComponent('{"field1":"asc"}') + '&api:page=0&api:pageSize=0';
     var requestParams = {
       query: DEFAULT_QUERY_OBJECT,
       search: {
@@ -254,7 +254,7 @@ describe('corbel resources module', function() {
       }
     };
 
-    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(URL_COLLECTION_DECODED.replace('api:search={"text":"test"}', 'api:search="test"'));
+    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(URL_COLLECTION_DECODED.replace('api:search=' + encodeURIComponent('{"text":"test"}'), 'api:search=' + encodeURIComponent('"test"')));
   });
 
   it('generate resource query correctly with custom query string', function() {
@@ -285,7 +285,7 @@ describe('corbel resources module', function() {
       }]
     };
 
-    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(TEST_ENDPOINT + 'resource/resource:entity?api:query=[{\"$eq\":{\"name\":\"Chewaçcá Sä+^*quñardel\"}}]');
+    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(TEST_ENDPOINT + 'resource/resource:entity?api:query=' + encodeURIComponent('[{\"$eq\":{\"name\":\"Chewaçcá Sä+^*quñardel\"}}]'));
   });
 
   it('generate resource multi query (OR)', function() {
@@ -308,7 +308,7 @@ describe('corbel resources module', function() {
       }
     };
 
-    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(TEST_ENDPOINT + 'resource/resource:entity?api:query=[{\"$eq\":{\"field3\":true}},{\"$eq\":{\"field4\":true}},{\"$gt\":{\"field5\":\"value\"}},{\"$gte\":{\"field5\":\"value\"}},{\"$lt\":{\"field5\":\"value\"}},{\"$lte\":{\"field5\":\"value\"}},{\"$ne\":{\"field5\":\"value\"}},{\"$in\":{\"field2\":[\"pepe\",\"juan\"]}},{\"$all\":{\"field5\":[\"pepe\",\"juan\"]}},{\"$like\":{\"field5\":\"value\"}}]&api:query=[{\"$eq\":{\"field3\":true}},{\"$eq\":{\"field4\":true}},{\"$gt\":{\"field5\":\"value\"}},{\"$gte\":{\"field5\":\"value\"}},{\"$lt\":{\"field5\":\"value\"}},{\"$lte\":{\"field5\":\"value\"}},{\"$ne\":{\"field5\":\"value\"}},{\"$in\":{\"field2\":[\"pepe\",\"juan\"]}},{\"$all\":{\"field5\":[\"pepe\",\"juan\"]}},{\"$like\":{\"field5\":\"value\"}}]&api:search={\"text\":\"test\"}&api:distinct=text,field1&api:sort={\"field1\":\"asc\"}&api:page=1&api:pageSize=5');
+    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(TEST_ENDPOINT + 'resource/resource:entity?api:query=' + encodeURIComponent('[{\"$eq\":{\"field3\":true}},{\"$eq\":{\"field4\":true}},{\"$gt\":{\"field5\":\"value\"}},{\"$gte\":{\"field5\":\"value\"}},{\"$lt\":{\"field5\":\"value\"}},{\"$lte\":{\"field5\":\"value\"}},{\"$ne\":{\"field5\":\"value\"}},{\"$in\":{\"field2\":[\"pepe\",\"juan\"]}},{\"$all\":{\"field5\":[\"pepe\",\"juan\"]}},{\"$like\":{\"field5\":\"value\"}}]') + '&api:query=' + encodeURIComponent('[{\"$eq\":{\"field3\":true}},{\"$eq\":{\"field4\":true}},{\"$gt\":{\"field5\":\"value\"}},{\"$gte\":{\"field5\":\"value\"}},{\"$lt\":{\"field5\":\"value\"}},{\"$lte\":{\"field5\":\"value\"}},{\"$ne\":{\"field5\":\"value\"}},{\"$in\":{\"field2\":[\"pepe\",\"juan\"]}},{\"$all\":{\"field5\":[\"pepe\",\"juan\"]}},{\"$like\":{\"field5\":\"value\"}}]') + '&api:search=' + encodeURIComponent('{\"text\":\"test\"}') + '&api:distinct=' + encodeURIComponent('text,field1') + '&api:sort=' + encodeURIComponent('{\"field1\":\"asc\"}') + '&api:page=1&api:pageSize=5');
   });
 
   it('generate resource multi query (OR)', function() {
@@ -357,7 +357,7 @@ describe('corbel resources module', function() {
       }
     };
 
-    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(TEST_ENDPOINT + 'resource/resource:entity?api:query=[{\"$like\":{\"title\":\"Praga\"}},{\"$in\":{\"_dst_id\":[\"books:Book/f44ee834b058d9f383acaece2d44613c\",\"books:Book/9979a1daf7c6eebf04375bd0fc37f3c3\"]}}]&api:query=[{\"$elem_match\":{\"authors\":[{\"$like\":{\"name\":\"Praga\"}}]}},{\"$in\":{\"_dst_id\":[\"books:Book/f44ee834b058d9f383acaece2d44613c\"]}}]&api:search={\"text\":\"test\"}&api:distinct=text,field1&api:sort={\"field1\":\"asc\"}&api:page=1&api:pageSize=5');
+    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(TEST_ENDPOINT + 'resource/resource:entity?api:query=' + encodeURIComponent('[{\"$like\":{\"title\":\"Praga\"}},{\"$in\":{\"_dst_id\":[\"books:Book/f44ee834b058d9f383acaece2d44613c\",\"books:Book/9979a1daf7c6eebf04375bd0fc37f3c3\"]}}]') + '&api:query=' + encodeURIComponent('[{\"$elem_match\":{\"authors\":[{\"$like\":{\"name\":\"Praga\"}}]}},{\"$in\":{\"_dst_id\":[\"books:Book/f44ee834b058d9f383acaece2d44613c\"]}}]') + '&api:search=' + encodeURIComponent('{\"text\":\"test\"}') + '&api:distinct=' + encodeURIComponent('text,field1') + '&api:sort=' + encodeURIComponent('{\"field1\":\"asc\"}') + '&api:page=1&api:pageSize=5');
   });
 
   it('resources.collection has mandatory parameters', function() {


### PR DESCRIPTION
Refactor to encode each query param in serialize params function.

This solutions fix the following problems:
- Query param with '&' symbol.
- Query param with few '=' symbols