### PR TITLE
fix search param when is query serching

### DIFF
--- a/dist/corbel.js
+++ b/dist/corbel.js
@@ -408,7 +408,7 @@
                 result += result ? '&' : '';
 
                 result += 'api:search=';
-                if (isJSON(params.search)) {
+                if (this.isJSON(params.search)) {
                     result += getJsonEncodedStringify(params.search);
                 } else {
                     result += encodeURIComponent(params.search);

--- a/dist/corbel.js
+++ b/dist/corbel.js
@@ -406,7 +406,13 @@
 
             if (params.search) {
                 result += result ? '&' : '';
-                result += 'api:search=' + getJsonEncodedStringify(params.search);
+
+                result += 'api:search=';
+                if (isJSON(params.search)) {
+                    result += getJsonEncodedStringify(params.search);
+                } else {
+                    result += encodeURIComponent(params.search);
+                }
 
                 if (params.hasOwnProperty('indexFieldsOnly')) {
                     result += '&api:indexFieldsOnly=' + getJsonEncodedStringify(params.indexFieldsOnly);

--- a/dist/corbel.js
+++ b/dist/corbel.js
@@ -408,7 +408,7 @@
                 result += result ? '&' : '';
 
                 result += 'api:search=';
-                if (this.isJSON(params.search)) {
+                if (params.search instanceof Object) {
                     result += getJsonEncodedStringify(params.search);
                 } else {
                     result += encodeURIComponent(params.search);

--- a/dist/corbel.with-polyfills.js
+++ b/dist/corbel.with-polyfills.js
@@ -1404,7 +1404,13 @@
 
             if (params.search) {
                 result += result ? '&' : '';
-                result += 'api:search=' + getJsonEncodedStringify(params.search);
+
+                result += 'api:search=';
+                if (isJSON(params.search)) {
+                    result += getJsonEncodedStringify(params.search);
+                } else {
+                    result += encodeURIComponent(params.search);
+                }
 
                 if (params.hasOwnProperty('indexFieldsOnly')) {
                     result += '&api:indexFieldsOnly=' + getJsonEncodedStringify(params.indexFieldsOnly);

--- a/dist/corbel.with-polyfills.js
+++ b/dist/corbel.with-polyfills.js
@@ -1406,7 +1406,7 @@
                 result += result ? '&' : '';
 
                 result += 'api:search=';
-                if (isJSON(params.search)) {
+                if (this.isJSON(params.search)) {
                     result += getJsonEncodedStringify(params.search);
                 } else {
                     result += encodeURIComponent(params.search);

--- a/dist/corbel.with-polyfills.js
+++ b/dist/corbel.with-polyfills.js
@@ -1406,7 +1406,7 @@
                 result += result ? '&' : '';
 
                 result += 'api:search=';
-                if (this.isJSON(params.search)) {
+                if (params.search instanceof Object) {
                     result += getJsonEncodedStringify(params.search);
                 } else {
                     result += encodeURIComponent(params.search);

--- a/src/utils.js
+++ b/src/utils.js
@@ -257,7 +257,7 @@
       result += result ? '&' : '';
 
       result += 'api:search=';
-      if (isJSON(params.search)) {
+      if (this.isJSON(params.search)) {
         result += getJsonEncodedStringify(params.search);
       } else {
         result += encodeURIComponent(params.search);

--- a/src/utils.js
+++ b/src/utils.js
@@ -255,7 +255,13 @@
 
     if (params.search) {
       result += result ? '&' : '';
-      result += 'api:search=' + getJsonEncodedStringify(params.search);
+
+      result += 'api:search=';
+      if (isJSON(params.search)) {
+        result += getJsonEncodedStringify(params.search);
+      } else {
+        result += encodeURIComponent(params.search);
+      }
 
       if (params.hasOwnProperty('indexFieldsOnly')) {
         result += '&api:indexFieldsOnly=' + getJsonEncodedStringify(params.indexFieldsOnly);

--- a/src/utils.js
+++ b/src/utils.js
@@ -257,7 +257,7 @@
       result += result ? '&' : '';
 
       result += 'api:search=';
-      if (this.isJSON(params.search)) {
+      if (params.search instanceof Object) {
         result += getJsonEncodedStringify(params.search);
       } else {
         result += encodeURIComponent(params.search);

--- a/test/node/unit/resources.js
+++ b/test/node/unit/resources.js
@@ -254,7 +254,7 @@ describe('corbel resources module', function() {
       }
     };
 
-    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(URL_COLLECTION_DECODED.replace('api:search=' + encodeURIComponent('{"text":"test"}'), 'api:search=' + encodeURIComponent('"test"')));
+    expect(resources.collection('resource:entity').getURL(requestParams)).to.be.equal(URL_COLLECTION_DECODED.replace('api:search=' + encodeURIComponent('{"text":"test"}'), 'api:search=' + encodeURIComponent('test')));
   });
 
   it('generate resource query correctly with custom query string', function() {


### PR DESCRIPTION
api:search admin two types of values, json when use a templated search (under development) and a simple string when use querystring, but when jsonstringify a simple string, the value takes doublequoted, (example-> api:query=search text, but gets api:query="search text") and this results in a query in elasticsearch that search the exact text. 